### PR TITLE
リスト結合演算子ブロックを追加

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -650,6 +650,35 @@ Blockly.Blocks['list_cons_typed'] = {
   }
 };
 
+Blockly.Blocks['list_append_typed'] = {
+  init: function() {
+    this.setColour(260);
+    var element_type = Blockly.TypeExpr.generateTypeVar();
+    var listType = new Blockly.TypeExpr.LIST(element_type);
+    this.appendValueInput('LEFT')
+        .setTypeExpr(listType);
+    this.appendValueInput('RIGHT')
+        .setTypeExpr(listType)
+        .appendField('@');
+    this.setOutput(true);
+    this.setOutputTypeExpr(listType);
+    this.setInputsInline(true);
+  },
+
+  infer: function(ctx) {
+    var expected = this.outputConnection.typeExpr;
+    var leftType = this.callInfer('LEFT', ctx);
+    var rightType = this.callInfer('RIGHT', ctx);
+    if (leftType) {
+      expected.unify(leftType);
+    }
+    if (rightType) {
+      expected.unify(rightType);
+    }
+    return expected;
+  }
+}
+
 /**
  * Pairs
  */

--- a/generators/typedlang.js
+++ b/generators/typedlang.js
@@ -63,7 +63,8 @@ Blockly.TypedLang.ORDER_MOD = 5.3;            // mod (INFIXOP3)
 Blockly.TypedLang.ORDER_SUBTRACTION = 6.1;    // - (INFIXOP2)
 Blockly.TypedLang.ORDER_ADDITION = 6.2;       // + (INFIXOP2)
 Blockly.TypedLang.ORDER_CONS = 7;             // ::
-Blockly.TypedLang.ORDER_CONCAT_STRING = 8;    // ^ (INFIXOP1)
+Blockly.TypedLang.ORDER_CONCAT_STRING = 8.1;  // ^ (INFIXOP1)
+Blockly.TypedLang.ORDER_APPEND_LIST = 8.2;    // @ (INFIXOP1)
 Blockly.TypedLang.ORDER_RELATIONAL = 9;       // < <= > >= = <> (INFIXOP0)
 Blockly.TypedLang.ORDER_LOGICAL_AND = 13;     // &&
 Blockly.TypedLang.ORDER_LOGICAL_OR = 14;      // ||

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -196,6 +196,15 @@ Blockly.TypedLang['list_cons_typed'] = function(block) {
   return [code, Blockly.TypedLang.ORDER_CONS];
 };
 
+Blockly.TypedLang['list_append_typed'] = function(block) {
+  var left = Blockly.TypedLang.valueToCode(block, 'LEFT',
+      Blockly.TypedLang.ORDER_APPEND_LIST) || '?';
+  var right = Blockly.TypedLang.valueToCode(block, 'RIGHT',
+      Blockly.TypedLang.ORDER_APPEND_LIST) || '?';
+  var code = left + ' @ ' + right;
+  return [code, Blockly.TypedLang.ORDER_APPEND_LIST];
+};
+
 Blockly.TypedLang['pair_create_typed'] = function(block) {
   var fst = Blockly.TypedLang.valueToCode(block, 'FIRST',
       Blockly.TypedLang.ORDER_COMMA) || '?';


### PR DESCRIPTION
`@` ブロックを追加しました。
左のメニューからは現れないので、block_of_ocaml を書き足さない限り使えません。