### PR TITLE
Changed list,pair,record,let tooltipss

### DIFF
--- a/blocks/datatypes.js
+++ b/blocks/datatypes.js
@@ -11,6 +11,7 @@ Blockly.Blocks['defined_recordtype_typed'] = {
   // Declare record types.
   init: function() {
     this.setColour('#008b8b');
+    this.setTooltip(Blockly.Msg.DEFINE_RECORD_TOOLTIP);
 
     this.recordId_ = Blockly.utils.genUid();
     var record_type = new Blockly.TypeExpr.RECORD(this.recordId_);

--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -7,6 +7,7 @@
 goog.require('Blockly.Blocks');
 goog.require('Blockly');
 
+
 Blockly.Blocks['logic_boolean_typed'] = {
   /**
    * Block for boolean data type: true and false.
@@ -51,8 +52,8 @@ Blockly.Blocks['logic_operator_typed'] = {
     this.setTooltip(function() {
       var mode = thisBlock.getFieldValue('OP_BOOL');
       var TOOLTIPS = {
-        'AND': 'Logical product operator.',
-        'OR': 'Logical sum operator.'
+        'AND': Blockly.Msg.LOGIC_OPERATION_AND,
+        'OR': Blockly.Msg.LOGIC_OPERATION_OR
       };
       return TOOLTIPS[mode];
     });
@@ -620,6 +621,7 @@ Blockly.Blocks['list_empty_typed'] = {
     this.setOutput(true);
     this.setOutputTypeExpr(listType);
     this.setInputsInline(true);
+    this.setTooltip(Blockly.Msg.LISTS_CREATE_EMPTY_TOOLTIP);
   }
 };
 
@@ -636,6 +638,7 @@ Blockly.Blocks['list_cons_typed'] = {
     this.setOutput(true);
     this.setOutputTypeExpr(listType);
     this.setInputsInline(true);
+    this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_CONTAINER_TOOLTIP);
   },
 
   infer: function(ctx) {
@@ -685,6 +688,7 @@ Blockly.Blocks['list_append_typed'] = {
 /**
  * Pairs
  */
+
 Blockly.Blocks['pair_create_typed'] = {
   init: function() {
     this.setColour(Blockly.Msg['PAIRS_HUE']);
@@ -729,7 +733,7 @@ Blockly.Blocks['pair_first_typed'] = {
     this.setOutput(true);
     this.setOutputTypeExpr(A);
     this.setInputsInline(true);
-    this.setTooltip('Get the first and second elements of a pair.');
+    this.setTooltip(Blockly.Msg.PAIR_GET_FIRST_TOOLTIP);
   },
 
   infer: function(ctx) {
@@ -757,7 +761,7 @@ Blockly.Blocks['pair_second_typed'] = {
     this.setOutput(true);
     this.setOutputTypeExpr(B);
     this.setInputsInline(true);
-    this.setTooltip('Get the second and second elements of a pair.');
+    this.setTooltip(Blockly.Msg.PAIR_GET_SECOND_TOOLTIP);
   },
 
   infer: function(ctx) {
@@ -1416,6 +1420,7 @@ Blockly.Blocks['let_typed'] = {
         .setAlign(Blockly.ALIGN_RIGHT);
     this.setMutator(new Blockly.Mutator(['parameters_arg_item']));
     this.setInputsInline(false);
+    this.setTooltip(Blockly.Msg.DEFINE_VARIABLE_TOOLTIP);
 
     var defaultRecFlag = opt_recur === true;
     this.isRecursive_ = false;
@@ -1560,12 +1565,13 @@ Blockly.Blocks['let_typed'] = {
       if (flag) {
         var recLabel = new Blockly.FieldLabel('rec');
         input.insertFieldAt(1, recLabel, 'REC_LABEL');
+        this.setTooltip(Blockly.Msg.DEFINE_LET_REC_TOOLTIP);
       } else {
         var refs = this.getRecursiveReferences();
         for (var i = 0, ref; ref = refs[i]; i++) {
           ref.getSourceBlock().dispose();
         }
-        input.removeField('REC_LABEL');
+        this.setTooltip(Blockly.Msg.DEFINE_LET_REC_TOOLTIP);
       }
       this.isRecursive_ = flag;
 

--- a/msg/json/ja.json
+++ b/msg/json/ja.json
@@ -269,8 +269,8 @@
 	"TEXT_REPLACE_TOOLTIP": "文に含まれるキーワードを置換する。",
 	"TEXT_REVERSE_MESSAGE0": "%1を逆順に",
 	"TEXT_REVERSE_HELPURL": "https://github.com/google/blockly/wiki/Text#reversing-text",
-	"TEXT_REVERSE_TOOLTIP": "文の文字を逆順にする。",
-	"LISTS_CREATE_EMPTY_HELPURL": "https://github.com/google/blockly/wiki/Lists#create-empty-list",
+  "TEXT_REVERSE_TOOLTIP": "文の文字を逆順にする。",
+  "LISTS_CREATE_EMPTY_HELPURL": "https://github.com/google/blockly/wiki/Lists#create-empty-list",
 	"LISTS_CREATE_EMPTY_TITLE": "空のリストを作成",
 	"LISTS_CREATE_EMPTY_TOOLTIP": "長さ０でデータ・レコードを含まない空のリストを返す",
 	"LISTS_CREATE_WITH_TOOLTIP": "項目数が不定のリストを作成。",
@@ -375,5 +375,11 @@
 	"PROCEDURES_HIGHLIGHT_DEF": "関数の内容を強調表示します。",
 	"PROCEDURES_CREATE_DO": "'%1' を作成",
 	"PROCEDURES_IFRETURN_TOOLTIP": "1番目の値が true の場合、2番目の値を返します。",
-	"PROCEDURES_IFRETURN_WARNING": "警告: このブロックは、関数定義内でのみ使用できます。"
+  "PROCEDURES_IFRETURN_WARNING": "警告: このブロックは、関数定義内でのみ使用できます。",
+  "DEFINE_RECORD_TOOLTIP": "レコードを宣言",
+  "DEFINE_VARIABLE_TOOLTIP": "変数の定義",
+	"DEFINE_LET_REC_TOOLTIP": "再帰関数の定義",
+	"DEFINE_LET_IN_TOOLTIP": "局所変数の定義",
+  "PAIR_GET_FIRST_TOOLTIP": "ペアの一つ目を取得する",
+  "PAIR_GET_SECOND_TOOLTIP": "ペアの二つ目を取得する"
 }

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -1214,3 +1214,10 @@ Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT = 'Say something...';
 Blockly.Msg.ADD_REC = 'Add rec';
 /// context menu - Remove 'rec' from a let block
 Blockly.Msg.REMOVE_REC = 'Remove rec';
+
+Blockly.Msg.DEFINE_RECORD_TOOLTIP = 'Record type';
+Blockly.Msg.DEFINE_VARIABLE_TOOLTIP = 'Define variable';
+Blockly.Msg.DEFINE_LET_REC_TOOLTIP = 'Define recursion function';
+Blockly.Msg.DEFINE_LET_IN_TOOLTIP = 'Define function';
+Blockly.Msg.PAIR_GET_FIRST_TOOLTIP = 'Get the first element of pair';
+Blockly.Msg.PAIR_GET_SECOND_TOOLTIP = 'Get the second element of pair';


### PR DESCRIPTION
ツールチップを変更しました.

　・変数とmatch文
　　- let_typed : 「変数の定義」
　　- let_rec : 「再帰関数の定義」

　・組とレコード定義
        - defined_record_typed : 「レコードを定義」

　・リスト
　　- list_empty_typed : 「長さ0でデータ、レコードを含まない空のリストを返す」
　　- list_cons_typed : 「追加・削除、またはセッションの順序変更して、このリストブロックを再構成する」

　・進んだ構文
　　- pair_first_typed : 「ペアの一つ目を取得する」
　　- pair_second_typed : 「ペアの二つ目を取得する」