### PR TITLE
右のエリアを広げるボタンを追加

### DIFF
--- a/demos/universe/dev.html
+++ b/demos/universe/dev.html
@@ -16,6 +16,7 @@
     <!--h1 class="titleHeader">テキスト-ブロック変換</h1-->
     <div class="content">
       <div class="codeToBlock">
+        <button id="switchButton" class="btn --square" onclick="Typed.switchArea()">&lt;&lt;</button>
         <form onsubmit="Typed.onClickConvert(event)">
           <div>
             <h2 class="contentTitle">OCaml => block</h2>

--- a/demos/universe/style.css
+++ b/demos/universe/style.css
@@ -18,6 +18,12 @@ body {
   height: 100%;
   width: 70%;
   float: left;
+  resize: horizontal;
+  overflow: hidden;
+}
+
+#workspaceArea[class~="--narrow"] {
+  width: 20%;
 }
 
 #rightArea {
@@ -26,6 +32,10 @@ body {
   float: left;
   overflow-x: hidden;
   overflow-y: auto;
+}
+
+#rightArea[class~="--wide"] {
+  width: 80%;
 }
 
 #rightArea > * {
@@ -64,6 +74,11 @@ textarea.ocamlCode, textarea.generatedCode {
   background-color: #d3d3d3;
   outline: none;
   width: 150px;
+}
+
+.btn[class~="--square"] {
+  height: 27px;
+  width: 30px;
 }
 
 .clear {

--- a/demos/universe/typed.js
+++ b/demos/universe/typed.js
@@ -148,6 +148,18 @@ Typed.getBBox_ = function(element) {
   };
 }
 
+Typed.switchArea = function() {
+  const workspaceArea = document.getElementById('workspaceArea');
+  const workspaceClasses = workspaceArea.classList;
+  workspaceClasses.toggle('--narrow');
+  const rightArea = document.getElementById('rightArea');
+  const rightClasses = rightArea.classList;
+  rightClasses.toggle('--wide');
+  const buttonElement = document.getElementById('switchButton');
+  buttonElement.innerText =
+    buttonElement.innerText === '<<' ? '>>' : '<<';
+}
+
 Typed.showCode = function() {
   try {
     var code = Blockly.TypedLang.workspaceToCode(Typed.workspace);


### PR DESCRIPTION
大きめのゲームを作りたかったので、押すとワークスペースと右の部分の境界線が移動するボタンを作りました。
ゲームが表示されるエリアの場所は変えていないので、縦に大きいゲームは表示しきれません。

私が使いたいだけなので、あまり良くなければ採用しないでいただいてかまいません。