### PR TITLE
Save・Load ボタンの後に改行

### DIFF
--- a/demos/universe/dev.html
+++ b/demos/universe/dev.html
@@ -32,10 +32,11 @@
               readonly></textarea>
           <button class="btn" onclick="Typed.showCode()">Update</button>
         </p-->
-        <button class="btn" id="download" onclick="Typed.saveCode()">Save</button>
-        <br>
-        <button class="btn" onclick="Typed.loadCode()">Load</button>
-        <input id="upload-file" type="file" accept=".ml" />
+        <button class="btn" id="download" onclick="Typed.saveCode()">Save</button><br>
+        <div class="box">
+          <input id="upload-file" type="file" accept=".ml" /><br>
+          <button class="btn" onclick="Typed.loadCode()">Load</button>
+        </div>
         <button class="btn" onclick="Typed.runCode()">Run</button>
         <button class="btn" onclick="Typed.runGame()">Run Game</button>
       </div>

--- a/demos/universe/style.css
+++ b/demos/universe/style.css
@@ -81,6 +81,17 @@ textarea.ocamlCode, textarea.generatedCode {
   width: 30px;
 }
 
+.box {
+  background-color: #eeeeee;
+  width: 200px;
+  padding: 3px 5px;
+  margin-top: 6px;
+}
+
+#upload-file {
+  width: 200px;
+}
+
 .clear {
   clear: both;
 }


### PR DESCRIPTION
Saveボタンの後とLoadボタンのうしろに改行を入れました。

変更前の画像
<img width="1017" alt="スクリーンショット 2019-07-12 12 20 21" src="https://user-images.githubusercontent.com/32429539/61100548-8df75f80-a4a1-11e9-9a6d-2bcf84bae726.png">
Save・Load ボタン追加と右のエリアの拡張を並行して別のブランチで行った結果、右のエリアを拡張したときにボタンが４つ横並びになってしまったのが気持ち悪かったので、改行を入れました。

改行を入れるとファイル選択と Load の関係が分かりにくくなったので、色付きの箱に入れました。

変更後の画像
<img width="612" alt="スクリーンショット 2019-07-12 12 34 18" src="https://user-images.githubusercontent.com/32429539/61100552-8fc12300-a4a1-11e9-88d1-d744cc2d7461.png">
