### PR TITLE
distinguish type block's color and define type block's color

### DIFF
--- a/blocks/datatypes.js
+++ b/blocks/datatypes.js
@@ -10,7 +10,7 @@ goog.require('Blockly');
 Blockly.Blocks['defined_recordtype_typed'] = {
   // Declare record types.
   init: function() {
-    this.setColour(Blockly.Msg['TYPES_HUE']);
+    this.setColour(Blockly.Msg['DEFINE_TYPES_HUE']);
     this.setTooltip(Blockly.Msg.DEFINE_RECORD_TOOLTIP);
 
     this.recordId_ = Blockly.utils.genUid();
@@ -174,7 +174,7 @@ Blockly.Blocks['defined_recordtype_typed'] = {
 
 Blockly.Blocks['create_record_typed'] = {
   init: function() {
-    this.setColour(Blockly.Msg['TYPES_HUE']);
+    this.setColour(Blockly.Msg['DEFINE_TYPES_HUE']);
     var recordType = new Blockly.TypeExpr.RECORD(null);
     var variableField =
         Blockly.FieldBoundVariable.newReferenceRecord(recordType);
@@ -321,7 +321,7 @@ Blockly.Blocks['create_record_typed'] = {
 Blockly.Blocks['defined_datatype_typed'] = {
   // Declare constructor types.
   init: function() {
-    this.setColour(Blockly.Msg['TYPES_HUE']);
+    this.setColour(Blockly.Msg['DEFINE_TYPES_HUE']);
     var validator = Blockly.BoundVariables.variableNameValidator.bind(null,
         Blockly.BoundVariableAbstract.VARIABLE);
 
@@ -481,7 +481,7 @@ Blockly.Blocks['defined_datatype_typed'] = {
 
 Blockly.Blocks['create_construct_typed'] = {
   init: function() {
-    this.setColour(Blockly.Msg['TYPES_HUE']);
+    this.setColour(Blockly.Msg['DEFINE_TYPES_HUE']);
     var ctrType = new Blockly.TypeExpr.CONSTRUCT(null);
     var variableField =
         Blockly.FieldBoundVariable.newReferenceConstructor(ctrType);

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -73,7 +73,9 @@ Blockly.Msg.PROCEDURES_HUE = '#d3869b';
 /// {{Notranslate}} Hue value for all pair blocks.
 Blockly.Msg.PAIRS_HUE = '#d5df00';
 /// {{Notranslate}} Hue value for all type blocks.
-Blockly.Msg.TYPES_HUE = '#8ec07c';
+Blockly.Msg.TYPES_HUE = '#83ccd2';
+/// {{Notranslate}} Hue value for all type blocks.
+Blockly.Msg.DEFINE_TYPES_HUE = '#8ec07c';
 /// {{Notranslate}} Hue value for all pattern blocks.
 Blockly.Msg.PATTERN_HUE = '#9b72b0';
 /// {{Notranslate}} Hue value for all string typed blocks.


### PR DESCRIPTION
型ブロックと型定義ブロックの色が同じになってしまっていたので、
カラーラベルを1つ追加し、区別させました。