### PR TITLE
Random.int と Random.float ブロックを追加

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -1557,6 +1557,60 @@ Blockly.Blocks['list_fold_left2_typed'] = {
 }
 
 /**
+ * module Random
+ */
+
+Blockly.Blocks['random_int_typed'] = {
+/**
+ * Block for Random.int function.
+ * @this Blockly.Block
+ */
+  init: function() {
+    this.setColour(Blockly.Msg['INT_HUE']);
+    this.setOutput(true, 'Int');
+    this.setOutputTypeExpr(new Blockly.TypeExpr.INT());
+    this.appendValueInput('A')
+        .setTypeExpr(new Blockly.TypeExpr.INT())
+        .appendField('Random.int');
+    this.setInputsInline(true);
+    this.setTooltip(Blockly.Msg.RANDOM_INT_TOOLTIP);
+  },
+
+  infer: function(ctx) {
+    var expected = new Blockly.TypeExpr.INT();
+    var arg = this.callInfer('A', ctx);
+    if (arg)
+      arg.unify(expected);
+    return expected;
+  }
+};
+
+Blockly.Blocks['random_float_typed'] = {
+  /**
+   * Block for Random.float function.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.setColour(Blockly.Msg['FLOAT_HUE']);
+    this.setOutput(true, 'Float');
+    this.setOutputTypeExpr(new Blockly.TypeExpr.FLOAT());
+    this.appendValueInput('A')
+        .setTypeExpr(new Blockly.TypeExpr.FLOAT())
+        .appendField('Random.float');
+    this.setInputsInline(true);
+    this.setTooltip(Blockly.Msg.RANDOM_FLOAT_TOOLTIP);
+  },
+
+  infer: function(ctx) {
+    var expected = new Blockly.TypeExpr.FLOAT();
+    var arg = this.callInfer('A', ctx);
+    if (arg)
+      arg.unify(expected);
+    return expected;
+  }
+};
+
+/**
  * Pairs
  */
 

--- a/demos/universe/dev.html
+++ b/demos/universe/dev.html
@@ -102,6 +102,8 @@
       <block type="defined_datatype_typed"></block>
       <block type="andmap_typed"></block>
       <block type="ormap_typed"></block>
+      <block type="random_int_typed"></block>
+      <block type="random_float_typed"></block>
     </category>
     <category name="Universe(画像)" colour="%{BKY_IMAGE_HUE}">
       <block type="text_typed"></block>

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -418,6 +418,22 @@ Blockly.TypedLang['list_map_typed'] = function(block) {
   return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
 };
 
+Blockly.TypedLang['random_int_typed'] = function(block) {
+  // function Random.int.
+  var argument = Blockly.TypedLang.valueToCode(block, 'A',
+      Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
+  var code = 'Random.int ' + argument;
+  return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
+};
+
+Blockly.TypedLang['random_float_typed'] = function(block) {
+  // function Random.float.
+  var argument = Blockly.TypedLang.valueToCode(block, 'A',
+      Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
+  var code = 'Random.float ' + argument;
+  return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
+};
+
 Blockly.TypedLang['pair_create_typed'] = function(block) {
   var fst = Blockly.TypedLang.valueToCode(block, 'FIRST',
       Blockly.TypedLang.ORDER_COMMA) || '?';

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -598,6 +598,9 @@ Blockly.Msg.STRING_OF_INT = 'Convert an integer to a string.';
 
 Blockly.Msg.STRING_CONCAT = 'Combine strings.';
 
+Blockly.Msg.RANDOM_INT_TOOLTIP = 'Generate a random integer between 0 and one less than the first argument.';
+Blockly.Msg.RANDOM_FLOAT_TOOLTIP = 'Generate a random float number between 0. and less than the first argument.';
+
 // Text Blocks.
 /// {{Optional}} url - Information about how computers represent text (sometimes referred to as ''string''s).
 Blockly.Msg.TEXT_TEXT_HELPURL = 'https://en.wikipedia.org/wiki/String_(computer_science)';


### PR DESCRIPTION
`Random.int` ブロックと `Random.float` ブロックを足しました。
<img width="900" alt="スクリーンショット 2019-07-13 10 07 43" src="https://user-images.githubusercontent.com/32429539/61165060-8ba30d00-a556-11e9-85f6-19363ecb6a57.png">
Universe のみ、ツールボックス？（左の部分）の「進んだ構文」の最後に追加しました。
基本的に `Random.int` は `abs` 、 `Random.float` は `sqrt` をコピーして作りました。

`Random.bool` も足そうと思っていたのですが、引数が `()` なので今回は諦めました。