### PR TITLE
実行結果の最後に水平線を追加

### DIFF
--- a/demos/typed/typed.js
+++ b/demos/typed/typed.js
@@ -161,6 +161,8 @@ Typed.runCode = function() {
   Blockly.PrintSemiSemi = false;
   console.log(code);
   evaluator.runCode(code);
+  const element = document.getElementById('toplevel');
+  element.insertAdjacentHTML('beforeend', '<hr>');
 }
 
 Typed.clearToplevel = function() {


### PR DESCRIPTION
Run ボタンを複数回押すとどこまでが一回の実行の結果なのかが分かりにくいので、毎回の実行結果の下に水平線を追加しました。
Clear を押すと水平線も消えます。
<img width="325" alt="スクリーンショット 2019-07-16 13 57 53" src="https://user-images.githubusercontent.com/32429539/61267189-d2e90200-a7d1-11e9-84e2-37cf9f91a8e5.png">
