### PR TITLE
Random.int と Random.float 内部の変数名を変更

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -1569,7 +1569,7 @@ Blockly.Blocks['random_int_typed'] = {
     this.setColour(Blockly.Msg['INT_HUE']);
     this.setOutput(true, 'Int');
     this.setOutputTypeExpr(new Blockly.TypeExpr.INT());
-    this.appendValueInput('A')
+    this.appendValueInput('PARAM0')
         .setTypeExpr(new Blockly.TypeExpr.INT())
         .appendField('Random.int');
     this.setInputsInline(true);
@@ -1578,7 +1578,7 @@ Blockly.Blocks['random_int_typed'] = {
 
   infer: function(ctx) {
     var expected = new Blockly.TypeExpr.INT();
-    var arg = this.callInfer('A', ctx);
+    var arg = this.callInfer('PARAM0', ctx);
     if (arg)
       arg.unify(expected);
     return expected;
@@ -1594,7 +1594,7 @@ Blockly.Blocks['random_float_typed'] = {
     this.setColour(Blockly.Msg['FLOAT_HUE']);
     this.setOutput(true, 'Float');
     this.setOutputTypeExpr(new Blockly.TypeExpr.FLOAT());
-    this.appendValueInput('A')
+    this.appendValueInput('PARAM0')
         .setTypeExpr(new Blockly.TypeExpr.FLOAT())
         .appendField('Random.float');
     this.setInputsInline(true);
@@ -1603,7 +1603,7 @@ Blockly.Blocks['random_float_typed'] = {
 
   infer: function(ctx) {
     var expected = new Blockly.TypeExpr.FLOAT();
-    var arg = this.callInfer('A', ctx);
+    var arg = this.callInfer('PARAM0', ctx);
     if (arg)
       arg.unify(expected);
     return expected;

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -420,7 +420,7 @@ Blockly.TypedLang['list_map_typed'] = function(block) {
 
 Blockly.TypedLang['random_int_typed'] = function(block) {
   // function Random.int.
-  var argument = Blockly.TypedLang.valueToCode(block, 'A',
+  var argument = Blockly.TypedLang.valueToCode(block, 'PARAM0',
       Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
   var code = 'Random.int ' + argument;
   return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
@@ -428,7 +428,7 @@ Blockly.TypedLang['random_int_typed'] = function(block) {
 
 Blockly.TypedLang['random_float_typed'] = function(block) {
   // function Random.float.
-  var argument = Blockly.TypedLang.valueToCode(block, 'A',
+  var argument = Blockly.TypedLang.valueToCode(block, 'PARAM0',
       Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
   var code = 'Random.float ' + argument;
   return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];


### PR DESCRIPTION
block-of-ocaml で List モジュールなどと統一的に処理するために、 `Random.int` と `Random.float` 内で使われている変数の名前を変更しました。

<img width="485" alt="スクリーンショット 2019-07-17 13 34 36" src="https://user-images.githubusercontent.com/32429539/61347468-0ee69a80-a898-11e9-93a6-6fbdf8aaa005.png">
変更後にこれらのブロックが使えてコードへの変換もできたことを確認した時の画像です。
