### PR TITLE
Color.t 型のコネクタの形を定義

### DIFF
--- a/core/rendered_type_expr.js
+++ b/core/rendered_type_expr.js
@@ -301,11 +301,11 @@ Blockly.RenderedTypeExpr.shape['unknown'] = {
 
 Blockly.RenderedTypeExpr.shape['Color.t'] = {
   down: function(steps) {
-    steps.push('l 0,5 a 6,6,0,0,0,0,12 l 0,3');
+    steps.push('l 0,7 -3,0 a 3,3,0,1,0,0,6 l 3,0 0,7');
   },
 
   up: function(steps) {
-    steps.push('l 0,-3 a 6,6,0,0,1,0,-12 l 0,-5');
+    steps.push('l 0,-7 -3,0 a 3,3,0,1,1,0,-6 l 3,0 0,-7');
   },
 
   height: function() {


### PR DESCRIPTION
Image.t 型の上の丸い部分を転用しました。
<img width="246" alt="スクリーンショット 2019-07-18 11 28 34" src="https://user-images.githubusercontent.com/32429539/61424657-33517e00-a94f-11e9-9992-9d39ea7703b4.png">
