### PR TITLE
(universe) float_of_int ブロックなどをメニューに追加

### DIFF
--- a/demos/universe/dev.html
+++ b/demos/universe/dev.html
@@ -57,16 +57,20 @@
       <block type="max_int_typed"></block>
       <block type="int_abs_typed"></block>
       <block type="random_int_typed"></block>
+      <block type="int_of_float_typed"></block>
       <block type="float_typed"></block>
       <block type="float_arithmetic_typed"></block>
       <block type="infinity_typed"></block>
       <block type="float_sqrt_typed"></block>
       <block type="random_float_typed"></block>
+      <block type="float_of_int_typed"></block>
     </category>
     <category name="文字列" colour="%{BKY_STRING_HUE}">
       <block type="string_typed"></block>
       <block type="concat_string_typed"></block>
       <block type="string_of_int_typed"></block>
+      <block type="string_of_float_typed"></block>
+      <block type="string_of_bool_typed"></block>
     </category>
     <category name="論理演算と条件文" colour="%{BKY_LOGIC_HUE}">
       <block type="logic_boolean_typed"></block>


### PR DESCRIPTION
ゲームを作るのに `float_of_int` などを使いたいので、メニューに追加しました。

追加したもの
`int_of_float` `float_of_int` `string_of_float` `string_of_bool`

追加しなかったもの（実行時エラーが怖いので）
`int_of_string` `bool_of_string`

そもそもブロックが無かったもの
`float_of_string`

<img width="368" alt="スクリーンショット 2019-07-18 20 12 37" src="https://user-images.githubusercontent.com/32429539/61453412-f7430b00-a998-11e9-91f5-1371f0893db3.png">

<img width="395" alt="スクリーンショット 2019-07-18 20 12 48" src="https://user-images.githubusercontent.com/32429539/61453311-bea33180-a998-11e9-8d0d-d47caeb3faf3.png">
