### PR TITLE
(universe) 保存するファイル名を入力するように変更

### DIFF
--- a/demos/universe/dev.html
+++ b/demos/universe/dev.html
@@ -35,7 +35,10 @@
               readonly></textarea>
           <button class="btn" onclick="Typed.showCode()">Update</button>
         </p-->
-        <button class="btn" id="download" onclick="Typed.saveCode()">Save</button><br>
+        <div class="box">
+          <span>File name: <input type="text" id="filename" size="16" value="game">.ml</span><br>
+          <button class="btn" id="download" onclick="Typed.saveCode()">Save</button>
+        </div>
         <div class="box">
           <input id="upload-file" type="file" accept=".ml" /><br>
           <button class="btn" onclick="Typed.loadCode()">Load</button>

--- a/demos/universe/style.css
+++ b/demos/universe/style.css
@@ -86,6 +86,7 @@ textarea.ocamlCode, textarea.generatedCode {
   width: 200px;
   padding: 3px 5px;
   margin-top: 6px;
+  font-size: 12px;
 }
 
 #upload-file {

--- a/demos/universe/typed.js
+++ b/demos/universe/typed.js
@@ -184,10 +184,12 @@ Typed.showCode = function() {
  */
 Typed.saveCode = function() {
   const fileContent = Blockly.TypedLang.workspaceToCode(Typed.workspace);
+  const fileNameElement = document.getElementById('filename');
+  const fileName = fileNameElement.value + '.ml';
   // 以下 https://qiita.com/kerupani129/items/99fd7a768538fcd33420 より
   const a = document.createElement('a');
   a.href = 'data:text/plain,' + encodeURIComponent(fileContent);
-  a.download = 'game.ml';
+  a.download = fileName;
   a.style.display = 'none';
   document.body.appendChild(a); // ※ DOM が構築されてからでないとエラーになる
   a.click();
@@ -204,6 +206,7 @@ Typed.loadCode = function() {
   const uploadFile = document.getElementById('upload-file');
   const file = uploadFile.files[0];
   if (!file) alert('ファイルを選択してください。');
+  else if (file.name.slice(-3) !== '.ml') alert('.ml ファイルを選択してください。');
   else {
     const reader = new FileReader();
     reader.readAsText(file);
@@ -214,6 +217,9 @@ Typed.loadCode = function() {
         BlockOfOCamlUtils.codeToBlock(code);
       }
     });
+    const fileName = file.name.slice(0, -3);
+    const fileNameElement = document.getElementById('filename');
+    fileNameElement.value = fileName;
   }
 }
 


### PR DESCRIPTION
Save ボタンの上にファイル名を入力する欄を作って、そこに入力されたファイル名で保存するようにしました。

<img width="344" alt="スクリーンショット 2019-07-19 12 08 36" src="https://user-images.githubusercontent.com/32429539/61506775-39faf680-aa1e-11e9-839c-532f7d3ac677.png">

### 動機
ゲームを作る上で何度もバックアップをしておきたくなったのですが、全部同じファイル名（game.ml）だとそれぞれどこまで書き進めた状態のファイルなのかが分かりにくいので、ファイル名を好きに変えたいと思いました。

### 変更内容
- `input` 要素を追加
  - 初期値は `game`.ml
  - `Save` ボタンに関する入力だと分かるように、色付きの同じ箱に入れた
- `Save` 時に、ファイル名を `input` 要素から取得するように変更
- `Load` 時に、`input` 要素のファイル名をロードするファイルの名前に書き換えるようにした
  - それにあたってファイル名から `.ml` を取り除く必要があったため、 `.ml` 以外のファイルはアップロードできないようになった