### PR TITLE
[] と None パターンブロックの修正

### DIFF
--- a/blocks/datatypes.js
+++ b/blocks/datatypes.js
@@ -973,6 +973,9 @@ Blockly.Blocks['empty_construct_pattern_typed'] = {
     valueBlock.initSvg();
     valueBlock.render();
     return valueBlock;
+  },
+
+  updateUpperContext: function(ctx) {
   }
 };
 
@@ -1076,6 +1079,9 @@ Blockly.Blocks['option_none_pattern_typed'] = {
     valueBlock.initSvg();
     valueBlock.render();
     return valueBlock;
+  },
+
+  updateUpperContext: function(ctx) {
   }
 };
 


### PR DESCRIPTION
画像の `true` ブロックを付けようとしたらエラーになってしまったので、付けられるように直しました。

<img width="800" alt="スクリーンショット 2019-07-21 11 06 04" src="https://user-images.githubusercontent.com/32429539/61586173-bcafbd00-aba8-11e9-8e52-4a3784f72803.png">
