### PR TITLE
[] と None ブロックの修正

### DIFF
--- a/blocks/datatypes.js
+++ b/blocks/datatypes.js
@@ -976,6 +976,9 @@ Blockly.Blocks['empty_construct_pattern_typed'] = {
   },
 
   updateUpperContext: function(ctx) {
+  },
+
+  removePatternReference: function() {
   }
 };
 
@@ -1082,6 +1085,9 @@ Blockly.Blocks['option_none_pattern_typed'] = {
   },
 
   updateUpperContext: function(ctx) {
+  },
+
+  removePatternReference: function() {
   }
 };
 


### PR DESCRIPTION
以下のプログラムの `let margin =` 以降のブロックをゴミ箱にドラッグしたらエラーになったので、そこでエラーにならないように書き換えました。（こういった関数は本当に必要なのでしょうか…）

```
let width = 300
let height = 300
let length = 100
type world_t = {
  cells : ((int * int) * bool option) list;
  player : bool;
}
let rec create_initial_cells x y =
  if y > 3 then []
  else (if x > 3 then create_initial_cells 1 (y + 1)
  else ((x, y), None) :: create_initial_cells (x + 1) y)
let initial_world = {cells = create_initial_cells 1 1; player = true}
let margin = 10
let shape_size = length + margin + margin
let line_size = 10
let line_size2 = (line_size * 5) / 7
let background = place_images [line [(0, height)] Color.black; line [(0, height)] Color.black; line [(width, 0)] Color.black; line [(width, 0)] Color.black] [(length, 0); (length * 2, 0); (0, length); (0, length * 2)] (empty_scene width height)
let true1 = circle (shape_size / 2) Color.red
let true2 = circle ((shape_size - line_size) / 2) Color.white
let false1 = polygon [(0, line_size2); (line_size2, 0); (shape_size - line_size2, shape_size); (shape_size, shape_size - line_size2)] Color.blue
let false2 = polygon [(shape_size - line_size2, 2); (shape_size, line_size2); (line_size2, shape_size); (0, shape_size - line_size2)] Color.blue
let cell_to_image1 (x2, y2) =
  match y2 with
  | None -> true1
  | Some s3 -> (if s3 then true1
  else false1)
let cell_to_image2 (x3, y5) =
  match y5 with
  | None -> true2
  | Some s5 -> (if s5 then true2
  else false2)
let cell_to_pos ((x4, y4), y3) =
  ((x4 - 1) * length + margin, (y4 - 1) * length + margin)
let draw {cells = cells_v; player = player_v} =
  let filterd_cells = List.filter (fun cell -> (match cell with
  | (a, (Some s7)) -> true
  | (x5, None) -> false)) cells_v
  in background
```