### PR TITLE
Load を押した時にファイルを開くダイアログが出るように

### DIFF
--- a/demos/universe/typed.js
+++ b/demos/universe/typed.js
@@ -207,13 +207,6 @@ Typed.loadCode = function() {
   const file = uploadFile.files[0];
   if (!file) {  // ファイルが選ばれていなかった場合
     uploadFile.click();  // ファイル選択ボタンをクリックしたことにする
-    var loop = setInterval(function() {  // 0.5秒ごとに繰り返し
-      console.log('Waiting for a file to be selected.');
-      if (uploadFile.files[0]) {  // ファイルが選択されたらループ終了してロードやり直し
-        clearInterval(loop);
-        Typed.loadCode();
-      }
-    }, 500);  // ファイルが選択されるまで setInterval が動き続ける
   } else if (file.name.slice(-3) !== '.ml') alert('.ml ファイルを選択してください。');
   else {
     const reader = new FileReader();

--- a/demos/universe/typed.js
+++ b/demos/universe/typed.js
@@ -205,8 +205,16 @@ Typed.loadCode = function() {
   // https://kuroeveryday.blogspot.com/2015/07/javascript-upload-download.html より
   const uploadFile = document.getElementById('upload-file');
   const file = uploadFile.files[0];
-  if (!file) alert('ファイルを選択してください。');
-  else if (file.name.slice(-3) !== '.ml') alert('.ml ファイルを選択してください。');
+  if (!file) {  // ファイルが選ばれていなかった場合
+    uploadFile.click();  // ファイル選択ボタンをクリックしたことにする
+    var loop = setInterval(function() {  // 0.5秒ごとに繰り返し
+      console.log('Waiting for a file to be selected.');
+      if (uploadFile.files[0]) {  // ファイルが選択されたらループ終了してロードやり直し
+        clearInterval(loop);
+        Typed.loadCode();
+      }
+    }, 500);  // ファイルが選択されるまで setInterval が動き続ける
+  } else if (file.name.slice(-3) !== '.ml') alert('.ml ファイルを選択してください。');
   else {
     const reader = new FileReader();
     reader.readAsText(file);


### PR DESCRIPTION
ファイルを選択していない状態で `Load` を押したらファイルダイアログが出るように変更しました。

## 動機
ファイルを選択していない状態で `Load` を押すと「ファイルを選択してください。」という alert が出ていたが、それを消し、ファイルを選択し、もう一度 `Load` を押すのは手間がかかる。
`Load` を押したらすぐにファイルを選べるようにしたい。

## 変更内容
- `Load` ボタンクリック時の、ファイルが選択されていない場合の動作を変更
  - 「ファイルを選択してください」アラートが出るのをやめた
  - 最初に「ファイルを選択」要素を押した時の動作（ファイルダイアログが出る）をするようにした
  - ~その後 0.5 秒ごとにファイル選択が完了したかどうかを判定し、選択されていたらもう一度 `Load` ボタンの関数を実行することで、ただちにブロックに変換されるようにした~

## 懸案事項
修正して解決しました。
- ~ファイルを選択されていない状態で `Load` を押すと 0.5 秒ごとのループが始まり、ファイルが選択された時点でループは停止するが、もしそのままファイルを選択せずに新しくブロックを組み始めたりすると、無駄に無限ループが動き続ける。~
  - ~あまりそんな人はいないかもしれないし Run Game を２回以上押すことよりは軽いと思うので無視してもいいかもしれない~