### PR TITLE
Added overlay block

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -86,6 +86,42 @@ Blockly.Blocks['read_image_typed'] = {
   }
 };
 
+Blockly.Blocks['overlay_typed'] = {
+  // overlay : Image.t -> (int * int) -> Image.t -> Image.t
+  init: function() {
+    var img   = new Blockly.TypeExpr.IMAGE();
+    var A     = new Blockly.TypeExpr.INT();
+    var B     = new Blockly.TypeExpr.INT();
+    var pair  = new Blockly.TypeExpr.TUPLE(A, B);
+    this.setColour(Blockly.Msg['IMAGE_HUE']);
+    this.appendValueInput('PARAM0')
+        .setTypeExpr(img)
+        .appendField('overlay ');
+    this.appendValueInput('PARAM1')
+        .setTypeExpr(pair);
+    this.appendValueInput('PARAM2')
+        .setTypeExpr(img);
+    this.setOutput(true);
+    this.setOutputTypeExpr(img);
+    this.setInputsInline(true);
+    this.setTooltip(Blockly.Msg.PLACE_IMAGE_TOOLTIP);
+  },
+  infer: function(ctx) {
+    var expected = this.outputConnection.typeExpr;
+    var img_typed = this.callInfer('PARAM0', ctx);
+    var pair_typed = this.callInfer('PARAM1', ctx);
+    var scene_typed = this.callInfer('PARAM2', ctx);
+    var pair_expected = this.getInput('PARAM1').connection.typeExpr;
+    if (img_typed)
+      img_typed.unify(img_typed);
+    if (pair_typed)
+      pair_typed.unify(pair_expected);
+    if (scene_typed)
+      scene_typed.unify(expected);
+    return expected;
+  }
+};
+
 Blockly.Blocks['place_image_typed'] = {
   // place_image : Image.t -> (int * int) -> scene_t -> scene_t
   init: function() {

--- a/demos/universe/dev.html
+++ b/demos/universe/dev.html
@@ -128,6 +128,7 @@
       <block type="text_typed"></block>
       <block type="line_typed"></block>
       <block type="polygon_typed"></block>
+      <block type="overlay_typed"></block>
     </category>
     <category name="背景" colour="%{BKY_SCENE_HUE}">
       <block type="empty_scene_typed"></block>

--- a/demos/universe/typed.js
+++ b/demos/universe/typed.js
@@ -229,6 +229,7 @@ Typed.programTop =
   "open Image;;\n" +
   "open World;;\n" +
   "open TransformToInt;;\n" +
+  "let overlay = place_image;;\n"
   "\n";
 
 Typed.clearCanvas = function () {

--- a/demos/universe/typed.js
+++ b/demos/universe/typed.js
@@ -229,7 +229,6 @@ Typed.programTop =
   "open Image;;\n" +
   "open World;;\n" +
   "open TransformToInt;;\n" +
-  "let overlay = place_image;;\n"
   "\n";
 
 Typed.clearCanvas = function () {

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -35,6 +35,17 @@ Blockly.TypedLang['read_image_typed'] = function(block) {
   return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
 };
 
+Blockly.TypedLang['overlay_typed'] = function(block) {
+  var img = Blockly.TypedLang.valueToCode(block, 'PARAM0',
+      Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
+  var pair = Blockly.TypedLang.valueToCode(block, 'PARAM1',
+      Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
+  var scene = Blockly.TypedLang.valueToCode(block, 'PARAM2',
+      Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
+  var code = 'overlay ' + img + ' ' + pair + ' ' + scene;
+  return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
+};
+
 Blockly.TypedLang['place_image_typed'] = function(block) {
   var img = Blockly.TypedLang.valueToCode(block, 'PARAM0',
       Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
@@ -83,7 +94,7 @@ Blockly.TypedLang['circle_typed'] = function(block) {
    Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
  var code1 = block.getFieldValue('IMAGE') === 'CIRCLE_OUTLINE' ? ' ~fill:false' : '' ;
  var code = 'circle ' + a + ' ' + color + code1;
- return [code, Blockly.TypedLang.ORDER_ATOMIC];
+ return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
 };
 
 Blockly.TypedLang['line_typed'] = function(block) {


### PR DESCRIPTION
`place_image` と同じことを `scene_t` の代わりに `Image.t` でできる `overlay` 関数ブロックを追加しました。
[問題点](#problem) があるので、修正したほうが良ければコメントをいただきたいです。

<img width="1440" alt="スクリーンショット 2019-07-22 13 15 25" src="https://user-images.githubusercontent.com/32429539/61606593-0de1ae80-ac86-11e9-898c-d7c45b9f4754.png">

## 動機
画像を組み合わせたものをさらに `place_image` の第１引数として他の画像に乗せたいことがあるが、 `place_image` の第１引数は `scene_t` 型なのでそういうことはできなかった。
`place_image : Image.t -> (int * int) -> scene_t -> scene_t` と同じことをする、
`overlay : Image.t -> (int * int) -> Image.t -> Image.t` という扱いのブロックが欲しい。

## 変更内容
- `overlay` ブロックを追加
- generator に `overlay` ブロックを追加
- `demos/universe/dev.html` に `overlay` ブロックを追加
- `Run` / `Run Game` 時のヘッダ(?)に `let overlay = place_image` を追加
- `circle` ブロックの generator に間違いがあったので修正

<a name="problem"></a>
## 問題点
実行時 `open` 文の直後に `let overlay = place_image` という文を足したため、 `Run` の結果が常に
```
val overlay :
UniverseJs.Image.t -> int * int -> UniverseJs.Image.t -> UniverseJs.Image.t =
<fun>
```
で始まってしまう。

これがまずいようなら、 `overlay` ブロックをコードにする時に `overlay` ではなく
`place_image (* onto_image *)` や
`((place_image)[@blockly.overlay ])` と書くなどの変更をしようと思います。
どちらが良いでしょうか？