### PR TITLE
text ブロックが使えるように修正

### DIFF
--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -149,7 +149,7 @@ Blockly.TypedLang['text_typed'] = function(block) {
       Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
   var color = Blockly.TypedLang.valueToCode(block, 'PARAM2',
       Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
-  var code = 'text ' + a + ' ' + b + ' ' + color;
+  var code = 'text ' + a + ' ~size:' + b + ' ' + color;
   return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
 };
 


### PR DESCRIPTION
`text` ブロックの型が Universe ライブラリの `text` 関数と異なっていて、実行するとエラーになる状態だったのを直しました。

## もとの問題
ライブラリでは `text : string -> ?size:float -> Color.t -> t` なのに対して、 `text` ブロックは `文字列` `サイズ` `色` をそれぞれ普通の引数としてとるので、`text` ブロックを使ったゲームを実行しようとするとエラーになった。

## 変更内容
`text` ブロックをコードに変換する際に、第２引数の前に `~size:` を付けた（make_color2 の alpha と同様）。

## 補足
- 第２引数が空欄だと `~size:?` と変換されるので実行できません。
- block-of-ocaml の変更はこれが merge された後にやります。

## 変更前の画像
<img width="1440" alt="スクリーンショット 2019-07-29 12 40 25" src="https://user-images.githubusercontent.com/32429539/62020670-e4cd9a80-b1fe-11e9-8e1f-d9bf7432761c.png">

## 変更後の画像
<img width="1440" alt="スクリーンショット 2019-07-29 12 41 13" src="https://user-images.githubusercontent.com/32429539/62020678-ea2ae500-b1fe-11e9-93c7-3717b4052c01.png">
