### PR TITLE
big_bang ブロックから生成される文字列を変更

### DIFF
--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -687,7 +687,7 @@ Blockly.TypedLang['dummy_statement_typed'] = function(block) {
 Blockly.TypedLang['big_bang_typed'] = function(block) {
   var initialWorldVar = Blockly.TypedLang.valueToCode(block, 'INITIAL_WORLD',
       Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
-  var code = 'let game_start = big_bang ' + initialWorldVar;
+  var code = ';; big_bang ' + initialWorldVar;
   if (block.nameCount_ >= 1) {
     code += '\n' + '  ' + '~name:';
     var nameVar = Blockly.TypedLang.valueToCode(block, 'NAME',


### PR DESCRIPTION
`big_bang` を OCaml に変換するときに、 `;; big_bang` とされるようにしました。