### PR TITLE
不等号の表示を全角記号から実際の演算子に変更

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -628,18 +628,18 @@ Blockly.Blocks['logic_compare_typed'] = {
   init: function() {
     var OPERATORS = Blockly.RTL ? [
           ['=', 'EQ'],
-          ['\u2260', 'NEQ'],
+          ['<>', 'NEQ'],
           ['>', 'LT'],
-          ['\u2265', 'LTE'],
+          ['>=', 'LTE'],
           ['<', 'GT'],
-          ['\u2264', 'GTE']
+          ['<=', 'GTE']
         ] : [
           ['=', 'EQ'],
-          ['\u2260', 'NEQ'],
+          ['<>', 'NEQ'],
           ['<', 'LT'],
-          ['\u2264', 'LTE'],
+          ['<=', 'LTE'],
           ['>', 'GT'],
-          ['\u2265', 'GTE']
+          ['>=', 'GTE']
         ];
     this.setHelpUrl(Blockly.Msg.LOGIC_COMPARE_HELPURL);
     this.setColour(Blockly.Msg['LOGIC_HUE']);


### PR DESCRIPTION
比較演算ブロック内に表示される不等号を実際の演算子と同じ記号に変更しました。

- `≠` → `<>`
- `≦` → `<=`
- `≧` → `>=`

読みづらさは否めないので、変更しないほうがよければ却下してください。
