### PR TITLE
&& と || の value 名を PARAMn に変更

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -567,9 +567,9 @@ Blockly.Blocks['logic_operator_typed'] = {
     this.setColour(Blockly.Msg['LOGIC_HUE']);
     this.setOutput(true, 'Boolean');
     this.setOutputTypeExpr(new Blockly.TypeExpr.BOOL());
-    this.appendValueInput('A')
+    this.appendValueInput('PARAM0')
         .setTypeExpr(new Blockly.TypeExpr.BOOL());
-    this.appendValueInput('B')
+    this.appendValueInput('PARAM1')
         .setTypeExpr(new Blockly.TypeExpr.BOOL())
         .appendField(new Blockly.FieldDropdown(OPERATORS, function (name) {
           var NAMES = {
@@ -578,7 +578,7 @@ Blockly.Blocks['logic_operator_typed'] = {
           };
           var op_name = NAMES[name];
           for (var x = 2; x < thisBlock.itemCount_; x++) {
-            var input = thisBlock.getInput('C' + x)
+            var input = thisBlock.getInput('PARAM' + x)
             input.removeField('OP' + x);
             input.appendField(op_name, 'OP' + x);
           }
@@ -615,9 +615,9 @@ Blockly.Blocks['logic_operator_typed'] = {
       // triggers type inference, which causes a null pointer exception. To
       // avoid the type inference for the removed input, update the size of
       // items first.
-      this.removeConnectedBlock('C' + index);
+      this.removeConnectedBlock('PARAM' + index);
       this.itemCount_--;
-      this.removeInput('C' + index);
+      this.removeInput('PARAM' + index);
     }
     var OPERATORS = {
       'AND': '&&',
@@ -626,7 +626,7 @@ Blockly.Blocks['logic_operator_typed'] = {
     var op_name = OPERATORS[this.getFieldValue('OP_BOOL')];
     while (this.itemCount_ < expectedCount) {
       var x = this.itemCount_;
-      var input = this.appendValueInput('C' + x)
+      var input = this.appendValueInput('PARAM' + x)
                       .setTypeExpr(new Blockly.TypeExpr.BOOL());
       input.appendField(op_name, 'OP' + x);
       this.itemCount_++;
@@ -689,14 +689,14 @@ Blockly.Blocks['logic_operator_typed'] = {
 
   infer: function(ctx) {
     var expected = new Blockly.TypeExpr.BOOL();
-    var left = this.callInfer('A', ctx);
-    var right = this.callInfer('B', ctx);
+    var left = this.callInfer('PARAM0', ctx);
+    var right = this.callInfer('PARAM1', ctx);
     if (left)
       left.unify(expected);
     if (right)
       right.unify(expected);
     for (var x = 2; x < this.itemCount_; x++) {
-      var c_type = this.callInfer('C' + x, ctx);
+      var c_type = this.callInfer('PARAM' + x, ctx);
       if (c_type)
         c_type.unify(expected);
     }

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -188,11 +188,11 @@ Blockly.TypedLang['logic_operator_typed'] = function(block) {
   var tuple = OPERATORS[block.getFieldValue('OP_BOOL')];
   var operator = tuple[0];
   var order = tuple[1];
-  var argument0 = Blockly.TypedLang.valueToCode(block, 'A', order) || '?';
-  var argument1 = Blockly.TypedLang.valueToCode(block, 'B', order) || '?';
+  var argument0 = Blockly.TypedLang.valueToCode(block, 'PARAM0', order) || '?';
+  var argument1 = Blockly.TypedLang.valueToCode(block, 'PARAM1', order) || '?';
   var code = argument0 + operator + argument1;
   for (var i = 2; i < block.itemCount_; i++) {
-    var argument = Blockly.TypedLang.valueToCode(block, 'C' + i,
+    var argument = Blockly.TypedLang.valueToCode(block, 'PARAM' + i,
         Blockly.TypedLang.ORDER_EXPR) || '?';
     code += operator + argument;
   }


### PR DESCRIPTION
block_of_ocaml を簡潔に書くために、 `&&` / `||` ブロックの引数の名前を `A`, `B`, `C2`, `C3`, ... から `PARAM0`, `PARAM1`, `PARAM2`,  ... に変更しました。
軽い動作確認をしました。
これが merge されたのを確認したら block_of_ocaml を変更します。