### PR TITLE
globalundostack改良

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -359,12 +359,21 @@ Blockly.hideChaff = function(opt_allowToolbox) {
 Blockly.undo = function(redo) {
     var inputStack = redo ? Blockly.globalRedoStack : Blockly.globalUndoStack;
     var outputStack = redo ? Blockly.globalUndoStack : Blockly.globalRedoStack;
-    var inputWorkspace = inputStack.pop();
+    var inputWorkspace = inputStack.slice(-1)[0];
     if (!inputWorkspace) {
-	return;
+	     return;
     }
-
-    inputWorkspace.undo(redo);
+    var groupid = inputWorkspace.groupid;
+    inputWorkspace.workspace.undo(redo);
+    if (Blockly.globalUndoStack.length > 0) {
+      if (Blockly.globalUndoStack.slice(-1)[0].groupid === groupid) {
+        var inputWorkspace2 = Blockly.globalUndoStack.slice(-1)[0];
+        if (!inputWorkspace2) {
+          return;
+        }
+        inputWorkspace2.workspace.undo(redo);
+      }
+    }
     outputStack.push(inputWorkspace);
 };
 

--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -133,6 +133,8 @@ Blockly.Events.UiWithUndo.prototype.run = function(forward) {
       var value = forward ? this.newValue : this.oldValue;
       if (this.element === 'mutatorOpen') {
         var mutator = block.mutator;
+      } else if (this.element === 'workbenchOpen') {
+        var mutator = block.mutator;
       } else {
         throw 'Not implemented';
       }
@@ -142,4 +144,3 @@ Blockly.Events.UiWithUndo.prototype.run = function(forward) {
       return;
   }
 };
-


### PR DESCRIPTION
undoをWorkspaceを跨いでできるようになりました。

- groupid が ""のものは、globalUndoStackに入らないようになっているので、今の所 Events.UiWithUndoは globalUndoStack には入っていません。