### PR TITLE
highlight機能改良

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -321,9 +321,11 @@ Blockly.onKeyDown_ = function(e) {
     if (e.shiftKey) {
       Blockly.createByKey(workspace, 'string_typed');
     }
-  } else if (e.keyCode == 222){
-    // ^ key = 222
-    Blockly.createByKey(workspace, 'concat_string_typed');
+  } else if (e.keyCode == 67){
+    // ^ key = 67
+    if (e.shiftKey) {
+      Blockly.createByKey(workspace, 'concat_string_typed');
+    }
   } else if (e.keyCode == 188){
     // = key = 189
       Blockly.createByKey(workspace, 'logic_compare_typed');

--- a/core/events.js
+++ b/core/events.js
@@ -169,9 +169,15 @@ Blockly.Events.FIRE_QUEUE_ = [];
  */
 Blockly.Events.fire = function(event) {
   if (Blockly.selectedConnection) {
-    var input = Blockly.selectedConnection;
-    input.connection.unhighlight();
+    var inputConnection = Blockly.selectedConnection;
+    inputConnection.unhighlight();
     Blockly.selectedConnection = null;
+  } else if (Blockly.selectedNextConnection) {
+    if (Blockly.selectedNextConnection) {
+      var nextConnection = Blockly.selectedNextConnection;
+      nextConnection.unhighlight();
+      Blockly.selectedNextConnection = null;
+    }
   }
   if (!Blockly.Events.isEnabled()) {
     return;


### PR DESCRIPTION
ハイライト機能で上下左右移動できるようになりました。
関数名だけどうすればいいかわからず、とりあえずの名前をつけました。

あと、shiftキーの操作の仕方を教えていただいてできるようになったので、ブロックの対応キーを少し変更しました。


●shift + 0 — 実数
●0 — 整数
●i  —  if
●a — abs
●s — sqrt
●shift + ;— +
●. — +.
●shift + 2 — 文字列
●shift + c — 文字列の結合

●b(boolean) — true,falseブロック
●n — not
●shift + 6 — &&, || ブロック
●- — =
●shift + l — let (inのあるやつ)
●l  — let (これはハイライトがなくても使えます。)
●m  —  match
●t — type
●p — pair ( , )

●shift + [  — 空リスト
●[ — 空じゃないリスト
●: — cons（リスト）
